### PR TITLE
use the latest aria2c binary

### DIFF
--- a/net.agalwood.Motrix.yml
+++ b/net.agalwood.Motrix.yml
@@ -115,14 +115,13 @@ modules:
     post-install:
       - install -Dm755 src/aria2c ${FLATPAK_DEST}/motrix/engine/aria2c
     sources:
-      - type: git
-        url: https://github.com/aria2/aria2.git
-        tag: release-1.36.0
-        commit: 21f476588c5deedbfef87073d3860b78abed3991
+      - type: archive
+        url: "https://github.com/aria2/aria2/releases/download/release-1.36.0/aria2-1.36.0.tar.xz"
+        sha256: 58d1e7608c12404f0229a3d9a4953d0d00c18040504498b483305bcb3de907a5
         x-checker-data:
           type: anitya
           project-id: 109
-          tag-template: release-$version
+          url-template: "https://github.com/aria2/aria2/releases/download/release-$version/aria2-$version.tar.xz"
           stable-only: true
 
   - name: start-script


### PR DESCRIPTION
Since the Motrix project hasn't been updated for a while, we should update the `aria2c` binary here to get the latest bug fixes and performance improvements.