### PR TITLE
chore: match Node.js version with upstream

### DIFF
--- a/net.agalwood.Motrix.yml
+++ b/net.agalwood.Motrix.yml
@@ -5,7 +5,7 @@ sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
 base-version: '22.08'
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node16
+  - org.freedesktop.Sdk.Extension.node18
 command: start-motrix
 finish-args:
   - --device=dri
@@ -23,11 +23,11 @@ modules:
     buildsystem: simple
     build-options:
       # Add the node bin directory.
-      append-path: /usr/lib/sdk/node16/bin:/app/yarn/bin:/run/build/motrix/flatpak-node/chromedrive
+      append-path: /usr/lib/sdk/node18/bin:/app/yarn/bin:/run/build/motrix/flatpak-node/chromedrive
       env:
         # Don't add ELECTRON_CACHE
         XDG_CACHE_HOME: /run/build/motrix/flatpak-node/cache
-        # npm_config_nodedir: /usr/lib/sdk/node16
+        # npm_config_nodedir: /usr/lib/sdk/node18
         npm_config_offline: 'true'
         npm_config_no_save: 'true'
         npm_config_cache: /run/build/motrix/flatpak-node/npm-cache


### PR DESCRIPTION
upgrade to Node.js 18: https://github.com/agalwood/Motrix/blob/69d3ade3050e94ba4ef51e035de4f2caacc7371b/.github/workflows/release.yml#L25