### PR TITLE
Remove GPU acceleration

### DIFF
--- a/net.agalwood.Motrix.yml
+++ b/net.agalwood.Motrix.yml
@@ -8,7 +8,6 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.node18
 command: start-motrix
 finish-args:
-  - --device=dri
   - --share=ipc
   - --share=network
   # aria2c requires this permission


### PR DESCRIPTION
This appears to be unnecessary as I've found the app to run fine with it disabled. It just creates unnecessary attack surface, something that Flatpak sandboxing is specifically designed to avoid.